### PR TITLE
Dinner (2/3) - Invalid guesses & Duplicate guesses without penalization 

### DIFF
--- a/hangman.rb
+++ b/hangman.rb
@@ -1,0 +1,275 @@
+# Amira Hailemariam & Alice Rhomieux 
+
+require 'colorize'
+
+class Hangman
+  def initialize
+    @game_word = pick_word
+    @wrong_letters = []
+    @errors = 0
+
+    # initialize array_of_slots with underscores
+    @num_of_slots = @game_word.length
+    @array_of_slots = []
+    @num_of_slots.times do
+      @array_of_slots.push("_ ")
+    end
+
+    @drawings = [[
+              "|     _________",
+              "|     |/      |",
+              "|     |      ",
+              "|     |      ",
+              "|     |       ",
+              "|     |      ",
+              "|     |",
+              "| ____|___"
+            ],
+            [
+              "|     _________",
+              "|     |/      |",
+              "|     |      " + "(_)".colorize(:red),
+              "|     |      ",
+              "|     |       ",
+              "|     |      ",
+              "|     |",
+              "| ____|___"
+            ],
+
+                        [
+              "|     _________",
+              "|     |/      |",
+              "|     |      (_)",
+              "|     |       " + "|".colorize(:light_yellow),
+              "|     |       ",
+              "|     |      ",
+              "|     |",
+              "| ____|___"
+            ],
+                                    [
+              "|     _________",
+              "|     |/      |",
+              "|     |      (_)",
+              "|     |       |",
+              "|     |       " + "|".colorize(:green),
+              "|     |      ",
+              "|     |",
+              "| ____|___"
+            ],
+                                    [
+              "|     _________",
+              "|     |/      |",
+              "|     |      (_)",
+              "|     |      "+ "\\".colorize(:cyan) + "|",
+              "|     |       |",
+              "|     |      ",
+              "|     |",
+              "| ____|___"
+            ],
+                                                [
+              "|     _________",
+              "|     |/      |",
+              "|     |      (_)",
+              "|     |      \\|" + "/".colorize(:blue),
+              "|     |       |",
+              "|     |      ",
+              "|     |",
+              "| ____|___"
+            ],
+                                                [
+              "|     _________",
+              "|     |/      |",
+              "|     |      (_)",
+              "|     |      \\|/ ",
+              "|     |       | ",
+              "|     |      " + "/ ".colorize(:magenta),
+              "|     |",
+              "| ____|___"
+            ],
+                                                [
+              "|     _________",
+              "|     |/      |",
+              "|     |      (_)",
+              "|     |      \\|/",
+              "|     |       |",
+              "|     |      / " + "\\ ".colorize(:light_black),
+              "|     |",
+              "| ____|___"
+]]
+
+    start
+  end
+
+  def pick_word
+    word_list = %w{cat dog egg horse donkey elephant pig monkey iguana cow goat unigoat eggplant mouse dragon phoenix}
+    random_word = word_list.sample
+    return random_word
+  end
+
+  def start
+    puts "Welcome to Hangman."
+    puts "Please type your letter guess. No numbers, punctuation, or spaces."
+    puts "Answer: #{@game_word}"
+
+    @now_playing = true
+    puts "To exit, type: quit."
+    draw_tree(0)
+
+    draw_slots
+    draw_wrong_guesses
+
+    play
+  end
+
+  def play
+    while @now_playing
+      guess = get_guess
+      check_guess(guess)
+      update_board
+      check_win
+    end
+  end
+
+  # ---------------------------------
+  # Guess Methods
+
+  def get_guess
+    input = gets.chomp.strip.downcase
+    if input == "quit" || input == "exit"
+      exit
+    else
+      guess = validate_input(input)
+    end
+    return guess
+  end
+
+  def validate_input(input)
+
+# This also works, but we like the next solution better
+    # valid = true
+    # input.split.each do |letter|
+    #     if !("a".."z").include?(letter)
+    #       valid = false
+    #     end
+    #   end
+
+    # if valid
+    #   return input
+    # else
+    #   puts "Invalid entry. Please enter only letters (no punctuation)."
+    #   get_guess
+    # end
+#
+
+    valid = false
+
+    while !valid
+      input.split("").each do |letter|
+        # enter and space do not count as mistakes
+        if letter == " " || !("a".."z").include?(letter)
+          puts "Error:".colorize(:red) + " Please only use letters. No numbers, punctuation, or spaces."
+          get_guess
+        end
+      end
+
+      valid = true
+      return input
+    end
+  end
+
+  def check_guess(guess_letter)
+    # check word input
+    if guess_letter.length > 1
+      if guess_letter == @game_word
+        # fill in array of slots with letters of guess word
+        guess_letter.split("").each_with_index do |letter, index|
+          @array_of_slots[index] = letter + " "
+        end
+        # @array_of_slots = guess_letter.split("")
+        # @array_of_slots.each do |letter|
+        #   letter += " "
+        # end
+      end
+    # guess_letter is just a letter or
+    else
+      # check if guess_letter is in game_word
+      if @game_word.include?(guess_letter)
+        # if letter was already figured out, return message
+        if @array_of_slots.join.include?(guess_letter)
+          puts "\nYou already figured out that letter."
+        end
+
+        # if letter not already guessed and is in game word, fill the corresponding blank with letter
+        (0...@num_of_slots).each do |index|
+          if @game_word[index] == guess_letter
+            @array_of_slots[index] = guess_letter + " "
+          end
+        end
+      # if guess letter is wrong
+      else
+        # only if wrong letter was not already guessed
+        if !@wrong_letters.include?(guess_letter)
+        # adds to wrong letter list
+          @wrong_letters.push(guess_letter)
+        # increases errors which will draw new body part
+          @errors += 1
+        else
+          # could move this to a better locaton for UI
+          puts "\nYou already made that guess."
+        end
+      end
+    end
+  end
+
+
+  # ---------------------------------
+  # Winning and Losing
+
+  def check_win
+    if @array_of_slots.join.delete(" ") == @game_word
+      win
+    else
+      if @errors >= @drawings.length - 1
+        lose
+      end
+    end
+  end
+
+  def win
+    @now_playing = false
+    puts "Congrats, you won."
+  end
+
+  def lose
+    @now_playing = false
+    puts "You FAILED. And got hanged."
+  end
+
+
+  # ---------------------------------
+  # Visual Methods
+  def draw_tree(error_level)
+    puts "\n"
+    @drawings[error_level].each do |row|
+      puts row
+    end
+  end
+
+  def draw_slots
+    slots = @array_of_slots.join
+    puts "\n#{ slots }"
+  end
+
+  def draw_wrong_guesses
+    puts "\nWrong guesses: " + @wrong_letters.join(" ")
+  end
+
+  def update_board
+    draw_tree(@errors)
+    draw_slots
+    draw_wrong_guesses
+  end
+
+end
+
+Hangman.new

--- a/hangman.rb
+++ b/hangman.rb
@@ -116,7 +116,7 @@ class Hangman
 
     draw_slots
     draw_wrong_guesses
-
+    puts " "
     play
   end
 
@@ -162,33 +162,34 @@ class Hangman
   end
 
   def check_guess(guess_letter)
-    # check word input
+    # is guess_letter one lettr or a word/phrase
     if guess_letter.length > 1
+      # if a word/phrase
+      # check if it's the answer
       if guess_letter == @game_word
-        # fill in array of slots with letters of guess word
+        # if it is, fill in array of slots with letters of the answer
         guess_letter.split("").each_with_index do |letter, index|
           @array_of_slots[index] = letter + " "
         end
-        # @array_of_slots = guess_letter.split("")
-        # @array_of_slots.each do |letter|
-        #   letter += " "
-        # end
       end
-    # guess_letter is just a letter or
+
+    # guess_letter is just a letter
     else
-      # check if guess_letter is in game_word
+      # check if the gussed letter is in game_word
       if @game_word.include?(guess_letter)
         # if letter was already figured out, return message
         if @array_of_slots.join.include?(guess_letter)
           puts "\nYou already figured out that letter."
         end
 
-        # if letter not already guessed and is in game word, fill the corresponding blank with letter
+        # if letter not already guessed and is in game word,
+        # fill the corresponding blank with letter
         (0...@num_of_slots).each do |index|
           if @game_word[index] == guess_letter
             @array_of_slots[index] = guess_letter + " "
           end
         end
+
       # if guess letter is wrong
       else
         # only if wrong letter was not already guessed
@@ -253,6 +254,7 @@ class Hangman
     draw_tree(@errors)
     draw_slots
     draw_wrong_guesses
+    puts " "
   end
 
 end

--- a/hangman.rb
+++ b/hangman.rb
@@ -1,5 +1,4 @@
-# Amira Hailemariam & Alice Rhomieux 
-
+# Pair: Alice Rhomieux
 require 'colorize'
 
 class Hangman
@@ -8,7 +7,7 @@ class Hangman
     @wrong_letters = []
     @errors = 0
 
-    # initialize array_of_slots with underscores
+    # initializes array_of_slots with underscores
     @num_of_slots = @game_word.length
     @array_of_slots = []
     @num_of_slots.times do
@@ -28,7 +27,7 @@ class Hangman
             [
               "|     _________",
               "|     |/      |",
-              "|     |      " + "(_)".colorize(:red),
+              "|     |      " + "(_)".red,
               "|     |      ",
               "|     |       ",
               "|     |      ",
@@ -40,7 +39,7 @@ class Hangman
               "|     _________",
               "|     |/      |",
               "|     |      (_)",
-              "|     |       " + "|".colorize(:light_yellow),
+              "|     |       " + "|".red,
               "|     |       ",
               "|     |      ",
               "|     |",
@@ -51,7 +50,7 @@ class Hangman
               "|     |/      |",
               "|     |      (_)",
               "|     |       |",
-              "|     |       " + "|".colorize(:green),
+              "|     |       " + "|".red,
               "|     |      ",
               "|     |",
               "| ____|___"
@@ -60,7 +59,7 @@ class Hangman
               "|     _________",
               "|     |/      |",
               "|     |      (_)",
-              "|     |      "+ "\\".colorize(:cyan) + "|",
+              "|     |      "+ "\\".red + "|",
               "|     |       |",
               "|     |      ",
               "|     |",
@@ -70,7 +69,7 @@ class Hangman
               "|     _________",
               "|     |/      |",
               "|     |      (_)",
-              "|     |      \\|" + "/".colorize(:blue),
+              "|     |      \\|" + "/".red,
               "|     |       |",
               "|     |      ",
               "|     |",
@@ -82,7 +81,7 @@ class Hangman
               "|     |      (_)",
               "|     |      \\|/ ",
               "|     |       | ",
-              "|     |      " + "/ ".colorize(:magenta),
+              "|     |      " + "/ ".red,
               "|     |",
               "| ____|___"
             ],
@@ -92,7 +91,7 @@ class Hangman
               "|     |      (_)",
               "|     |      \\|/",
               "|     |       |",
-              "|     |      / " + "\\ ".colorize(:light_black),
+              "|     |      / " + "\\ ".red,
               "|     |",
               "| ____|___"
 ]]
@@ -144,31 +143,16 @@ class Hangman
   end
 
   def validate_input(input)
-
-# This also works, but we like the next solution better
-    # valid = true
-    # input.split.each do |letter|
-    #     if !("a".."z").include?(letter)
-    #       valid = false
-    #     end
-    #   end
-
-    # if valid
-    #   return input
-    # else
-    #   puts "Invalid entry. Please enter only letters (no punctuation)."
-    #   get_guess
-    # end
-#
-
     valid = false
 
     while !valid
       input.split("").each do |letter|
         # enter and space do not count as mistakes
+        # correctly identifies 1st invalid input
+        # submits 2nd as a wrong guess
         if letter == " " || !("a".."z").include?(letter)
-          puts "Error:".colorize(:red) + " Please only use letters. No numbers, punctuation, or spaces."
-          get_guess
+          puts "\nError:".red + " Please only use letters. No numbers, punctuation, or spaces."
+          input = gets.chomp.strip.downcase
         end
       end
 
@@ -214,7 +198,8 @@ class Hangman
         # increases errors which will draw new body part
           @errors += 1
         else
-          # could move this to a better locaton for UI
+          # would be cool if last added body part wasn't still red
+          # to show that the guess had no effect
           puts "\nYou already made that guess."
         end
       end


### PR DESCRIPTION
I didn't get to the part in Dinner about making various difficulty levels. You'll need the gem `colorize` for the error messages.

Duplicate guesses work fine. The program identifies that the guess has been submitted before and outputs a message informing the user. The user isn't penalized for duplicating their guess and the game continues.

Invalid guess including spaces, enters, numbers and punctuation are recognized and a message is outputted to the user. Unfortunately, there was a bug I couldn't quite figure out.  Spaces and enters were considered a duplicate guess and output that error message. But if the guess was recognized as invalid, after the error message was printed and the user guessed a second invalid guess, that second guess was considered a wrong guess and the user was penalized. The user was never prompted to guess again; the game simply continued. 

I worked on this for a while but ended up breaking the entire game and had to revert back a few commits.
